### PR TITLE
location of data/sample.xml now local, not Zenodo

### DIFF
--- a/quick_run.sh
+++ b/quick_run.sh
@@ -29,8 +29,6 @@ then
     mkdir data
 fi
 cd data
-# Downloading the sample data
-wget https://zenodo.org/record/3605388/files/sample.xml
 
 if [ ! -d "results" ]
 then


### PR DESCRIPTION
I copied data/sample.xml here to GitHub and will remove it from Zenodo. Changed the quick_run.sh script accordingly.